### PR TITLE
Develop

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,7 @@
 shamefully-hoist=true
 engine-strict=true
-save-exact = true
+save-exact=true
 tag-version-prefix=""
-strict-peer-dependencies = false
-auto-install-peers = true
-lockfile = true
+strict-peer-dependencies=false
+auto-install-peers=true
+lockfile=true

--- a/src/components/IconsPageMain/Card/index.tsx
+++ b/src/components/IconsPageMain/Card/index.tsx
@@ -62,7 +62,7 @@ const IconComponent = ({ item }: IconComponentProps) => {
   return (
     <Image
       loader={myLoader}
-      src={`/${item.icon}`}
+      src={`${item.icon}`}
       alt={item.name}
       width={140}
       height={140}

--- a/src/components/IconsPageMain_1.2.0/Card/index.tsx
+++ b/src/components/IconsPageMain_1.2.0/Card/index.tsx
@@ -62,7 +62,7 @@ const IconComponent = ({ item }: IconComponentProps) => {
   return (
     <Image
       loader={myLoader}
-      src={`/${item.icon}`}
+      src={`${item.icon}`}
       alt={item.name}
       width={140}
       height={140}

--- a/src/components/IconsPageMain_1.3.0/Card/index.tsx
+++ b/src/components/IconsPageMain_1.3.0/Card/index.tsx
@@ -62,7 +62,7 @@ const IconComponent = ({ item }: IconComponentProps) => {
   return (
     <Image
       loader={myLoader}
-      src={`/${item.icon}`}
+      src={`${item.icon}`}
       alt={item.name}
       width={140}
       height={140}

--- a/src/components/IconsPageMain_2.1.0/Card/index.tsx
+++ b/src/components/IconsPageMain_2.1.0/Card/index.tsx
@@ -62,7 +62,7 @@ const IconComponent = ({ item }: IconComponentProps) => {
   return (
     <Image
       loader={myLoader}
-      src={`/${item.icon}`}
+      src={`${item.icon}`}
       alt={item.name}
       width={140}
       height={140}

--- a/src/components/IconsPageMain_3.0.0/Card/index.tsx
+++ b/src/components/IconsPageMain_3.0.0/Card/index.tsx
@@ -62,7 +62,7 @@ const IconComponent = ({ item }: IconComponentProps) => {
   return (
     <Image
       loader={myLoader}
-      src={`/${item.icon}`}
+      src={`${item.icon}`}
       alt={item.name}
       width={140}
       height={140}


### PR DESCRIPTION
This pull request includes updates to multiple versions of the `IconComponent` to remove the leading slash from the `src` property of the `Image` component. This change ensures consistent handling of the `item.icon` path across versions.

Updates to `IconComponent`:

* [`src/components/IconsPageMain/Card/index.tsx`](diffhunk://#diff-1aaf7978bc93fbe03cdc577e7d9becc7799a0152b1ab0b2a9e5c15602d04a344L65-R65): Updated the `src` property to remove the leading slash from `item.icon`.
* [`src/components/IconsPageMain_1.2.0/Card/index.tsx`](diffhunk://#diff-1683dbfbac1a9ddd2b886d1c5add59cc524a908d9fa4201977507f98f9de16deL65-R65): Updated the `src` property to remove the leading slash from `item.icon`.
* [`src/components/IconsPageMain_1.3.0/Card/index.tsx`](diffhunk://#diff-cdf559c357dc6bc805e67e39b700ae8e741f8a545588b97c72dd38e450a87c3fL65-R65): Updated the `src` property to remove the leading slash from `item.icon`.
* [`src/components/IconsPageMain_2.1.0/Card/index.tsx`](diffhunk://#diff-73baeb326f6f1984d7d7de5acfb1a075deea4a9791f229e83e42be0921f0730fL65-R65): Updated the `src` property to remove the leading slash from `item.icon`.
* [`src/components/IconsPageMain_3.0.0/Card/index.tsx`](diffhunk://#diff-e399d54c865fe252802493bf90ac42b66c7267c303332205201b5bff694adfb0L65-R65): Updated the `src` property to remove the leading slash from `item.icon`.